### PR TITLE
[#12] Open API 불러온 후 DTO 변환 기능 추가

### DIFF
--- a/src/main/java/ttf/lost/application/avatar/AvatarService.java
+++ b/src/main/java/ttf/lost/application/avatar/AvatarService.java
@@ -1,0 +1,11 @@
+package ttf.lost.application.avatar;
+
+import ttf.lost.domain.avatar.Avatar;
+
+public interface AvatarService {
+	/**
+	 * 착용 중인 아바타 정보 가져오기
+	 * @param nickname 캐릭터 닉네임
+	 */
+	Avatar findUserAvatar(String nickname);
+}

--- a/src/main/java/ttf/lost/application/avatar/AvatarServiceFacade.java
+++ b/src/main/java/ttf/lost/application/avatar/AvatarServiceFacade.java
@@ -1,0 +1,20 @@
+package ttf.lost.application.avatar;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import ttf.lost.presentation.api.avatar.response.AvatarDtoResponse;
+
+@Service
+@RequiredArgsConstructor
+public class AvatarServiceFacade {
+	private final AvatarService avatarService;
+
+	public AvatarDtoResponse findUserAvatarAndPrice(String nickname) {
+		// TODO : Open API 호출 후 DTO에 저장,
+		avatarService.findUserAvatar(nickname);
+		// TODO : Repository에 정보 및 가격 저장
+		// TODO : 가격을 모두 더해주기
+		return null;
+	}
+}

--- a/src/main/java/ttf/lost/application/avatar/LostArkAvatarService.java
+++ b/src/main/java/ttf/lost/application/avatar/LostArkAvatarService.java
@@ -1,0 +1,19 @@
+package ttf.lost.application.avatar;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import ttf.lost.domain.avatar.Avatar;
+import ttf.lost.infrastructure.api.avatar.AvatarAPIClient;
+
+@Service
+@RequiredArgsConstructor
+public class LostArkAvatarService implements AvatarService {
+	private final AvatarAPIClient avatarAPIClient;
+
+	@Override
+	public Avatar findUserAvatar(String nickname) {
+		avatarAPIClient.findAvatar(nickname);
+		return null;
+	}
+}

--- a/src/main/java/ttf/lost/infrastructure/api/avatar/AvatarAPIClient.java
+++ b/src/main/java/ttf/lost/infrastructure/api/avatar/AvatarAPIClient.java
@@ -1,0 +1,11 @@
+package ttf.lost.infrastructure.api.avatar;
+
+import java.util.List;
+
+public interface AvatarAPIClient {
+	/**
+	 * Lost Ark Open API 에서 아바타 정보 가져오기
+	 * @param nickname
+	 */
+	List<AvatarDto> findAvatar(String nickname);
+}

--- a/src/main/java/ttf/lost/infrastructure/api/avatar/AvatarDto.java
+++ b/src/main/java/ttf/lost/infrastructure/api/avatar/AvatarDto.java
@@ -1,0 +1,68 @@
+package ttf.lost.infrastructure.api.avatar;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ttf.lost.common.annotation.JsonPaths;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class AvatarDto {
+	@JsonPaths("Type")
+	private String type;
+	@JsonPaths("Name")
+	private String name;
+	@JsonPaths("Icon")
+	private String icon;
+	@JsonPaths("Grade")
+	private String grade;
+	@JsonPaths("IsSet")
+	private String isSet;
+	@JsonPaths("IsInner")
+	private String isInner;
+
+	//**<P ALIGN='CENTER'><FONT COLOR='#F99200'>암흑 사제의 블레이드</FONT></P>*//*
+	@JsonPaths("Tooltip.Element_000.value")
+	private String avatarNameFont;
+	//**"leftStr0": "<FONT SIZE='12'><FONT COLOR='#F99200'>전설 검 아바타</FONT></FONT>"*//*
+	@JsonPaths("Tooltip.Element_001.value.leftStr0")
+	private String avatarGradeFont;
+	//**"<FONT SIZE='12'>블레이드 전용</FONT>"*//*
+	@JsonPaths("Tooltip.Element_002.value")
+	private String classNameFont;
+	/**"<FONT COLOR='#A9D0F5'>기본 효과</FONT>"*/
+	@JsonPaths("Tooltip.Element_005.value.Element_000")
+	private String baseEffectFont1;
+	// Inner = true일 경우
+	@JsonPaths("Tooltip.Element_006.value.Element_000")
+	private String baseEffectFont2;
+
+	/**"민첩 +2.00%"*/
+	@JsonPaths("Tooltip.Element_005.value.Element_001")
+	private String effect1;
+	// Inner false일 경우
+	@JsonPaths("Tooltip.Element_006.value.Element_000")
+	private String effect2;
+	/**"&tdc_smart 지성 : 5<BR>&tdc_courage 담력 : 5<BR>&tdc_charm 매력 : 5<BR>&tdc_kind 친절 : 5<BR><BR>"*/
+	@JsonPaths("Tooltip.Element_006.value.contentStr")
+	private String tendencyText1;
+	/**"<FONT COLOR='#A9D0F5'>성향</FONT>"*/
+	@JsonPaths("Tooltip.Element_007.value.contentStr")
+	private String tendencyText2;
+
+	@JsonPaths("Tooltip.Element_007.value")
+	private String tendencyFont1;
+	@JsonPaths("Tooltip.Element_007.value.titleStr")
+	private String tendencyFont2;
+
+}
+
+

--- a/src/main/java/ttf/lost/infrastructure/api/avatar/LostArkUserAvatarAPI.java
+++ b/src/main/java/ttf/lost/infrastructure/api/avatar/LostArkUserAvatarAPI.java
@@ -1,0 +1,43 @@
+package ttf.lost.infrastructure.api.avatar;
+
+import java.util.List;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import ttf.lost.common.utils.LostArkAPIResponseParser;
+
+@Service
+@RequiredArgsConstructor
+public class LostArkUserAvatarAPI implements AvatarAPIClient {
+	private final RestTemplate restTemplate;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public List<AvatarDto> findAvatar(String nickname) {
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Authorization",
+			"bearer {OPEN_API_KEY}"); // Open API Key 부분은 올리지 않고, yml 처리도 아직 되지 않았기에 따로 문자열로 선언합니다.
+
+		HttpEntity<?> request = new HttpEntity<>(headers);
+
+		String urlString = "https://developer-lostark.game.onstove.com/armories/characters/{value}?filters=avatars";
+		UriComponents uri = UriComponentsBuilder.fromHttpUrl(urlString).buildAndExpand(nickname);
+
+		ResponseEntity<String> result =
+			restTemplate.exchange(uri.toUriString(), HttpMethod.GET, request, String.class);
+		String body = result.getBody();
+		return LostArkAPIResponseParser.parseJson(body, AvatarDto.class, objectMapper);
+	}
+}

--- a/src/main/java/ttf/lost/presentation/api/avatar/AvatarController.java
+++ b/src/main/java/ttf/lost/presentation/api/avatar/AvatarController.java
@@ -1,0 +1,61 @@
+package ttf.lost.presentation.api.avatar;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import ttf.lost.application.avatar.AvatarServiceFacade;
+import ttf.lost.infrastructure.api.avatar.AvatarDto;
+import ttf.lost.infrastructure.api.avatar.LostArkUserAvatarAPI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/avatar")
+@Tag(name = "find_user_avatar", description = "유저 아바타와 가격 가져오기")
+public class AvatarController {
+	private final LostArkUserAvatarAPI apiTest;
+	private final AvatarServiceFacade avatarServiceFacade;
+
+	/**
+	 * 임시 DTO 변환 확인 테스트이기에
+	 * 별도로 Controller를 따로 만들어 테스트를 진행하였습니다.
+	 */
+	@GetMapping("/test/{nickname}")
+	public List<AvatarDto> getTest(
+		@PathVariable String nickname
+	) throws JsonProcessingException {
+		return apiTest.findAvatar(nickname);
+	}
+
+	@Operation(
+		operationId = "find_user_avatar",
+		summary = "findUserAvatar API 테스트",
+		description = "유저의 정보(닉네임)을 가져와서 착용 중인 캐릭터의 아바타 정보를 가져옵니다.",
+		tags = {"find_user_avatar"},
+		responses = {
+			@ApiResponse(responseCode = "200", description = "successful operation", content = {
+				@Content(mediaType = "application/json", schema = @Schema(implementation = String.class))
+			}),
+			@ApiResponse(responseCode = "400", description = "Invalid input"),
+			@ApiResponse(responseCode = "500", description = "Internal server error")
+		}
+	)
+	@GetMapping("/{nickname}")
+	public ResponseEntity<Object> findUserAvatar(
+		@PathVariable String nickname) {
+		avatarServiceFacade.findUserAvatarAndPrice(nickname);
+		return null;
+	}
+}

--- a/src/main/java/ttf/lost/presentation/api/avatar/response/AvatarDtoResponse.java
+++ b/src/main/java/ttf/lost/presentation/api/avatar/response/AvatarDtoResponse.java
@@ -1,0 +1,20 @@
+package ttf.lost.presentation.api.avatar.response;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AvatarDtoResponse {
+	private String name;
+	private String tooltip;
+	private BigDecimal price;
+}


### PR DESCRIPTION
### Change Cause : 
<!-- 무슨 이유로 코드를 변경했는지 최대 3줄로 요약해서 작성해주세요. -->
- Open API(Avatar 부분)를 불러와 파싱 후 DTO로 변환

***
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 As-is, To-be를 활용해서 작성해주세요.  -->
**As-is🔨**

- LostArk API Avatar 가져오기 (DTO)

**To-be🤔**

- 가져온 데이터 거래소에 쓰일 데이터(Parameter) Repository에 저장

Facade 패턴을 이용해 Service를 ServiceFacade 단에서 조립해서 사용하게 되는데, **Open API를 사용하는 Service의 경우는
따로 분리를 해서 Service에서 사용할 수 있게 처리**했습니다.

**Screenshot**
<!-- 사진이 필요하다면 같이 기재해 주세요. -->


### Test Check List ✔️
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
<!-- Test Code가 작성되어 있다면 해당 란에 체크를, PostMan 등으로 API 테스트 했다면 해당 란에 체크를 해주세요. 둘 다라면, 둘 다 체크. -->
- [ ] Test Code
- [x] API Test
